### PR TITLE
Fix for dev stringr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.1
 Roxygen: list(markdown = TRUE)
 URL: https://bstaton1.github.io/postpack/
 BugReports: https://github.com/bstaton1/postpack/issues

--- a/R/match_params.R
+++ b/R/match_params.R
@@ -47,8 +47,8 @@
 #' # turn off auto escape to use [] in regex syntax rather than matching them as text
 #' match_params(cjs, params = "[:digit:]$", auto_escape = FALSE)
 #'
-#' # pass an empty string to match all (same as get_params)
-#' match_params(cjs, "")
+#' # pass a dot to match all (same as get_params)
+#' match_params(cjs, ".")
 #' @export
 
 match_params = function(post, params, type = "base_index", auto_escape = TRUE) {

--- a/man/match_params.Rd
+++ b/man/match_params.Rd
@@ -67,6 +67,6 @@ match_params(cjs, "s.+0")
 # turn off auto escape to use [] in regex syntax rather than matching them as text
 match_params(cjs, params = "[:digit:]$", auto_escape = FALSE)
 
-# pass an empty string to match all (same as get_params)
-match_params(cjs, "")
+# pass a dot to match all (same as get_params)
+match_params(cjs, ".")
 }

--- a/man/post_convert.Rd
+++ b/man/post_convert.Rd
@@ -25,7 +25,7 @@ Accepted classes are produced by several packages, including but probably not li
 \item \code{\link[R2jags:jags]{rjags}} objects are created by \code{\link[R2jags:jags]{R2jags::jags()}}.
 \item \code{\link[base:list]{list}} objects are created by \code{\link[nimble:runMCMC]{nimble::runMCMC()}}, 'MCMCpack' functions, or custom MCMC algorithms.
 \item \code{\link[base:matrix]{matrix}} objects are created by \code{\link[=post_subset]{post_subset()}} and is often the format of posterior quantities derived from monitored nodes.
-\item \code{\link[coda:mcmc.list]{mcmc.list}} objects are created by \code{\link[rjags:coda.samples]{rjags::coda.samples()}}, \code{\link[jagsUI:jagsbasic]{jagsUI::jags.basic()}}, and \code{\link[jagsUI:jags]{jagsUI::jags()}}\verb{$samples}. If a \code{\link[coda:mcmc.list]{mcmc.list}} object is passed to \code{obj}, an error will be returned telling the user this function is not necessary.
+\item \code{\link[coda:mcmc.list]{mcmc.list}} objects are created by \code{\link[rjags:coda.samples]{rjags::coda.samples()}}, \code{\link[jagsUI:jags.basic]{jagsUI::jags.basic()}}, and \code{\link[jagsUI:jags]{jagsUI::jags()}}\verb{$samples}. If a \code{\link[coda:mcmc.list]{mcmc.list}} object is passed to \code{obj}, an error will be returned telling the user this function is not necessary.
 }
 
 If you find that a critical class conversion is missing, please submit an \href{https://github.com/bstaton1/postpack/issues}{issue} requesting its addition with a minimum working example of how it can be created.

--- a/vignettes/multiple-models.Rmd
+++ b/vignettes/multiple-models.Rmd
@@ -66,7 +66,7 @@ sapply(post_list, get_params, type = "base_index")
 You could verify that all parameters in both models converged well according to the `Rhat` statistic:
 
 ```{r}
-sapply(post_list, function(model) post_summ(model, "", Rhat = TRUE)["Rhat",])
+sapply(post_list, function(model) post_summ(model, ".", Rhat = TRUE)["Rhat",])
 ```
 
 (The `NaN` values for `"SIG[1,2]"` and `"SIG[2,1]"` in the `no_rho` model are because those had the same value each MCMC iteration).


### PR DESCRIPTION
`str_detect(x, pattern = "")` now returns an error because it was effectively equivalent to `x != ""` when you could equally expect it to match nothing. I made the simplest change to your code to get your package working which is to instead use a pattern that will always match.